### PR TITLE
Allow exponentation to the power of 0

### DIFF
--- a/paganini/expressions.py
+++ b/paganini/expressions.py
@@ -49,7 +49,10 @@ class Expr(object):
 
     def __pow__(self, n):
         """ Expression exponentiation."""
-        assert n > 0, 'Non-positive exponent.'
+        assert n >= 0, 'negative exponent.'
+
+        if n == 0:
+            return Expr(coeff=1, variables=Counter())
 
         xs = Counter(self.variables)
         for v in self.variables:

--- a/paganini/tests.py
+++ b/paganini/tests.py
@@ -442,6 +442,12 @@ class UtilsTuner(unittest.TestCase):
 
 class ExpressionsTest(unittest.TestCase):
 
+    def assertExprEqual(self, x, y):
+        self.assertIsInstance(x, Expr)
+        self.assertIsInstance(y, Expr)
+        self.assertEqual(x.coeff, y.coeff)
+        self.assertEqual(x.variables, y.variables)
+
     def test_related_expressions(self):
         x, y, z = Variable(), Variable(), Variable()
 
@@ -450,6 +456,13 @@ class ExpressionsTest(unittest.TestCase):
         self.assertFalse(x.related(x * x))
         self.assertTrue((x * y).related(y * x))
         self.assertFalse((x * y * z).related(y * x))
+
+    def test_exponentiation(self):
+        x = Variable()
+
+        self.assertExprEqual(x ** 0, Expr(1))
+        self.assertExprEqual(x ** 1, x)
+        self.assertExprEqual(x ** 3, x * x * x)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi Maciej,

Sometimes it can be useful to write expressions like `x ** 0`, especially when programmatically generating expressions.

This patch implement exponentiation to the 0 as `x ** 0 = Expr(1)`

Are you okay with this change?

Cheers